### PR TITLE
Remove unused dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ python -m pip install --upgrade pip
 pip install -e .
 ```
 
-The command installs the packages listed in `pyproject.toml`, such as `ffmpeg-python` and `click`, and makes `video_trim` available in editable mode.
+The command installs `video_trim` in editable mode.
 ## Overview
 `video_trim` demonstrates how to trim and reencode video segments using FFmpeg. The examples output MKV files encoded with the HEVC (H.265) codec.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,10 +8,7 @@ version = "0.1.0"
 description = "Trim videos using ffmpeg"
 readme = "README.md"
 requires-python = ">=3.8"
-dependencies = [
-    "ffmpeg-python",
-    "click",
-]
+dependencies = []
 
 [project.optional-dependencies]
 dev = ["pytest"]


### PR DESCRIPTION
## Summary
- drop `ffmpeg-python` and `click` from runtime dependencies
- update README to no longer mention those packages

## Testing
- `pytest -q` *(fails: SyntaxError in `video_trim/gui.py`)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc9eef3c48320875b43f5c426feeb