### PR TITLE
Ensure GUI exits cleanly

### DIFF
--- a/video_trim/gui.py
+++ b/video_trim/gui.py
@@ -69,9 +69,7 @@ class VideoTrimApp(tk.Tk):
         self.remaining_label.pack(pady=5)
 
         tk.Button(self, text="Select Video", command=self.select_file).pack(pady=5)
-=======
         tk.Button(self, text="Select Folder", command=self.select_directory).pack(pady=5)
-main
 
         time_frame = tk.Frame(self)
         time_frame.pack(pady=5, fill="x", padx=10)
@@ -89,18 +87,12 @@ main
         self.end_entry.pack()
 
         tk.Button(self, text="Trim and Convert", command=self.trim_and_convert).pack(pady=10)
-        tk.Button(self, text="Select Folder", command=self.select_directory).pack(pady=5)
-=======
-main
         tk.Button(self, text="Convert Directory to MKV", command=self.convert_directory).pack(pady=5)
 
         bottom_frame = tk.Frame(self)
         bottom_frame.pack(side="bottom", fill="x", pady=10)
         tk.Label(bottom_frame, text=f"Version {__version__}").pack(side="left", padx=10)
         tk.Button(bottom_frame, text="Exit", command=self.confirm_exit).pack(side="right", padx=10)
-=======
-        tk.Button(bottom_frame, text="Exit", command=self.quit).pack(side="right", padx=10)
-main
 
     def select_file(self) -> None:
         """Open a file dialog and display the selected file name."""
@@ -172,10 +164,10 @@ main
     def confirm_exit(self) -> None:
         """Prompt the user to confirm application exit."""
         if messagebox.askokcancel("Exit", "Close the application?"):
+            # ``destroy`` closes the window and ``quit`` ensures the main loop
+            # terminates, allowing the application to exit cleanly.
+            self.destroy()
             self.quit()
-
-=======
-main
 
 if __name__ == "__main__":  # pragma: no cover - GUI entry point
     app = VideoTrimApp()


### PR DESCRIPTION
## Summary
- call `destroy()` before `quit()` to close the GUI and stop the main loop
- clean up merge markers in `video_trim/gui.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdca01cc948320a11fd2b01ef62900