### PR TITLE
Handle FFmpeg execution errors

### DIFF
--- a/video_trim/cli.py
+++ b/video_trim/cli.py
@@ -9,12 +9,13 @@ from __future__ import annotations
 
 import argparse
 import subprocess
+import sys
 from typing import Sequence
 
 from video_trim import __version__
 
 
-def trim_video(input_file: str, start: str, end: str, output_file: str) -> None:
+def trim_video(input_file: str, start: str, end: str, output_file: str) -> int:
     """Trim a video using FFmpeg.
 
     Parameters
@@ -45,7 +46,15 @@ def trim_video(input_file: str, start: str, end: str, output_file: str) -> None:
         output_file,
     ]
 
-    subprocess.run(command, check=True)
+    try:
+        subprocess.run(command, check=True)
+    except FileNotFoundError:
+        print("ffmpeg not found. Please install ffmpeg and ensure it is in your PATH.", file=sys.stderr)
+        return 1
+    except subprocess.CalledProcessError as exc:
+        print(f"ffmpeg failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -59,12 +68,12 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: Sequence[str] | None = None) -> None:
+def main(argv: Sequence[str] | None = None) -> int:
     """Entry point for the command line interface."""
     parser = build_parser()
     args = parser.parse_args(argv)
-    trim_video(args.input, args.start, args.end, args.output)
+    return trim_video(args.input, args.start, args.end, args.output)
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point
-    main()
+    raise SystemExit(main())

--- a/video_trim/gui.py
+++ b/video_trim/gui.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 import tkinter as tk
 from tkinter import filedialog, messagebox
 
@@ -16,19 +17,7 @@ VIDEO_EXTENSIONS = {
 
 
 def convert_directory_to_mkv(directory: str) -> list[str]:
-    """Convert all non-MKV video files in ``directory`` to MKV.
-
-    Parameters
-    ----------
-    directory:
-        Path to the root directory to traverse.
-
-    Returns
-    -------
-    list[str]
-        Paths to the converted files.
-    """
-
+    """Convert all non-MKV video files in ``directory`` to MKV."""
     converted: list[str] = []
     for root, _, files in os.walk(directory):
         out_dir = os.path.join(root, "converted")
@@ -41,9 +30,20 @@ def convert_directory_to_mkv(directory: str) -> list[str]:
             out_name = os.path.splitext(name)[0] + ".mkv"
             out_path = os.path.join(out_dir, out_name)
             command = ["ffmpeg", "-i", in_path, "-c", "copy", out_path]
-            subprocess.run(command, check=True)
+            try:
+                subprocess.run(command, check=True)
+            except FileNotFoundError:
+                print(
+                    "ffmpeg not found. Please install ffmpeg and ensure it is in your PATH.",
+                    file=sys.stderr,
+                )
+                raise
+            except subprocess.CalledProcessError as exc:
+                print(f"ffmpeg failed: {exc}", file=sys.stderr)
+                raise
             converted.append(out_path)
     return converted
+
 
 from video_trim import __version__
 
@@ -69,9 +69,7 @@ class VideoTrimApp(tk.Tk):
         self.remaining_label.pack(pady=5)
 
         tk.Button(self, text="Select Video", command=self.select_file).pack(pady=5)
-=======
         tk.Button(self, text="Select Folder", command=self.select_directory).pack(pady=5)
-main
 
         time_frame = tk.Frame(self)
         time_frame.pack(pady=5, fill="x", padx=10)
@@ -89,18 +87,16 @@ main
         self.end_entry.pack()
 
         tk.Button(self, text="Trim and Convert", command=self.trim_and_convert).pack(pady=10)
-        tk.Button(self, text="Select Folder", command=self.select_directory).pack(pady=5)
-=======
-main
-        tk.Button(self, text="Convert Directory to MKV", command=self.convert_directory).pack(pady=5)
+        tk.Button(
+            self, text="Convert Directory to MKV", command=self.convert_directory
+        ).pack(pady=5)
 
         bottom_frame = tk.Frame(self)
         bottom_frame.pack(side="bottom", fill="x", pady=10)
         tk.Label(bottom_frame, text=f"Version {__version__}").pack(side="left", padx=10)
-        tk.Button(bottom_frame, text="Exit", command=self.confirm_exit).pack(side="right", padx=10)
-=======
-        tk.Button(bottom_frame, text="Exit", command=self.quit).pack(side="right", padx=10)
-main
+        tk.Button(bottom_frame, text="Exit", command=self.confirm_exit).pack(
+            side="right", padx=10
+        )
 
     def select_file(self) -> None:
         """Open a file dialog and display the selected file name."""
@@ -151,6 +147,11 @@ main
 
         try:
             subprocess.run(command, check=True)
+        except FileNotFoundError:
+            messagebox.showerror(
+                "Error", "ffmpeg not found. Please install ffmpeg and ensure it is in your PATH."
+            )
+            return
         except subprocess.CalledProcessError as exc:  # pragma: no cover - subprocess failure
             messagebox.showerror("Error", f"FFmpeg failed: {exc}")
             return
@@ -164,7 +165,10 @@ main
             return
         try:
             converted = convert_directory_to_mkv(self.directory_path)
-        except subprocess.CalledProcessError as exc:  # pragma: no cover - subprocess failure
+        except (
+            FileNotFoundError,
+            subprocess.CalledProcessError,
+        ) as exc:  # pragma: no cover - subprocess failure
             messagebox.showerror("Error", f"FFmpeg failed: {exc}")
             return
         messagebox.showinfo("Success", f"Converted {len(converted)} file(s)")
@@ -174,9 +178,8 @@ main
         if messagebox.askokcancel("Exit", "Close the application?"):
             self.quit()
 
-=======
-main
 
 if __name__ == "__main__":  # pragma: no cover - GUI entry point
     app = VideoTrimApp()
     app.mainloop()
+


### PR DESCRIPTION
## Summary
- Add error handling for missing or failing FFmpeg in CLI and GUI
- Return non-zero exit codes and show friendly messages when FFmpeg isn't available
- Clean up GUI file structure and fix syntax issues

## Testing
- `python -m py_compile video_trim/cli.py video_trim/gui.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bdca0e9780832086b9402206399789