### PR TITLE
Validate time format before trimming videos

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from video_trim.cli import trim_video
 
 
 def test_cli_help() -> None:
@@ -16,3 +22,35 @@ def test_cli_help() -> None:
     )
     assert result.returncode == 0
     assert "usage" in result.stdout.lower()
+
+
+def test_trim_video_invalid_time(monkeypatch) -> None:
+    """Providing an invalid time raises ``ValueError`` before running FFmpeg."""
+
+    def fake_run(cmd: list[str], check: bool) -> subprocess.CompletedProcess[str]:  # pragma: no cover - not executed
+        raise AssertionError("FFmpeg should not be invoked")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(ValueError):
+        trim_video("in.mp4", "00:00", "00:00:10", "out.mp4")
+
+
+def test_cli_invalid_time() -> None:
+    """The CLI reports an error for an invalid time format."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "video_trim",
+            "input.mp4",
+            "00:00:00",
+            "invalid",
+            "output.mp4",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert "Invalid end time" in result.stderr

--- a/video_trim/cli.py
+++ b/video_trim/cli.py
@@ -9,9 +9,32 @@ from __future__ import annotations
 
 import argparse
 import subprocess
+from datetime import datetime
 from typing import Sequence
 
 from video_trim import __version__
+
+
+def _validate_time(timestr: str, label: str) -> None:
+    """Validate that ``timestr`` is in ``HH:MM:SS`` format.
+
+    Parameters
+    ----------
+    timestr:
+        The time string to validate.
+    label:
+        A human-readable label used in error messages.
+
+    Raises
+    ------
+    ValueError
+        If ``timestr`` is not in the expected format.
+    """
+
+    try:
+        datetime.strptime(timestr, "%H:%M:%S")
+    except ValueError as exc:  # pragma: no cover - error branch
+        raise ValueError(f"Invalid {label} time '{timestr}'; expected HH:MM:SS") from exc
 
 
 def trim_video(input_file: str, start: str, end: str, output_file: str) -> None:
@@ -31,6 +54,9 @@ def trim_video(input_file: str, start: str, end: str, output_file: str) -> None:
     This is a placeholder implementation that invokes FFmpeg. Additional
     validation and error handling will be added later.
     """
+
+    _validate_time(start, "start")
+    _validate_time(end, "end")
 
     command = [
         "ffmpeg",
@@ -63,7 +89,10 @@ def main(argv: Sequence[str] | None = None) -> None:
     """Entry point for the command line interface."""
     parser = build_parser()
     args = parser.parse_args(argv)
-    trim_video(args.input, args.start, args.end, args.output)
+    try:
+        trim_video(args.input, args.start, args.end, args.output)
+    except ValueError as exc:  # pragma: no cover - user error path
+        parser.error(str(exc))
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/video_trim/gui.py
+++ b/video_trim/gui.py
@@ -69,9 +69,7 @@ class VideoTrimApp(tk.Tk):
         self.remaining_label.pack(pady=5)
 
         tk.Button(self, text="Select Video", command=self.select_file).pack(pady=5)
-=======
         tk.Button(self, text="Select Folder", command=self.select_directory).pack(pady=5)
-main
 
         time_frame = tk.Frame(self)
         time_frame.pack(pady=5, fill="x", padx=10)
@@ -89,18 +87,12 @@ main
         self.end_entry.pack()
 
         tk.Button(self, text="Trim and Convert", command=self.trim_and_convert).pack(pady=10)
-        tk.Button(self, text="Select Folder", command=self.select_directory).pack(pady=5)
-=======
-main
         tk.Button(self, text="Convert Directory to MKV", command=self.convert_directory).pack(pady=5)
 
         bottom_frame = tk.Frame(self)
         bottom_frame.pack(side="bottom", fill="x", pady=10)
         tk.Label(bottom_frame, text=f"Version {__version__}").pack(side="left", padx=10)
         tk.Button(bottom_frame, text="Exit", command=self.confirm_exit).pack(side="right", padx=10)
-=======
-        tk.Button(bottom_frame, text="Exit", command=self.quit).pack(side="right", padx=10)
-main
 
     def select_file(self) -> None:
         """Open a file dialog and display the selected file name."""
@@ -173,9 +165,6 @@ main
         """Prompt the user to confirm application exit."""
         if messagebox.askokcancel("Exit", "Close the application?"):
             self.quit()
-
-=======
-main
 
 if __name__ == "__main__":  # pragma: no cover - GUI entry point
     app = VideoTrimApp()


### PR DESCRIPTION
## Summary
- ensure start and end times use HH:MM:SS by validating with `datetime.strptime`
- surface a friendly CLI error when times are invalid
- clean up GUI file merge leftovers and add tests for invalid times

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdca137a9c832094448dc00fb378f6