### PR TITLE
Fix GUI and CLI modules

### DIFF
--- a/video_trim/cli.py
+++ b/video_trim/cli.py
@@ -9,58 +9,25 @@ from __future__ import annotations
 
 import argparse
 import subprocess
-
-from datetime import datetime
-
 import sys
-main
+from datetime import datetime
 from typing import Sequence
 
 from video_trim import __version__
 
+
 def _validate_time(timestr: str, label: str) -> None:
-    """Validate that ``timestr`` is in ``HH:MM:SS`` format.
-
-    Parameters
-    ----------
-    timestr:
-        The time string to validate.
-    label:
-        A human-readable label used in error messages.
-
-    Raises
-    ------
-    ValueError
-        If ``timestr`` is not in the expected format.
-    """
-
+    """Validate that ``timestr`` is in ``HH:MM:SS`` format."""
     try:
         datetime.strptime(timestr, "%H:%M:%S")
     except ValueError as exc:  # pragma: no cover - error branch
-        raise ValueError(f"Invalid {label} time '{timestr}'; expected HH:MM:SS") from exc
+        raise ValueError(
+            f"Invalid {label} time '{timestr}'; expected HH:MM:SS"
+        ) from exc
 
-
-def trim_video(input_file: str, start: str, end: str, output_file: str) -> None:
 
 def trim_video(input_file: str, start: str, end: str, output_file: str) -> int:
-main
-    """Trim a video using FFmpeg.
-
-    Parameters
-    ----------
-    input_file:
-        Path to the input video.
-    start:
-        Start time in ``HH:MM:SS`` format.
-    end:
-        End time in ``HH:MM:SS`` format.
-    output_file:
-        Path to the trimmed output video.
-
-    This is a placeholder implementation that invokes FFmpeg. Additional
-    validation and error handling will be added later.
-    """
-
+    """Trim a video using FFmpeg."""
     _validate_time(start, "start")
     _validate_time(end, "end")
 
@@ -80,7 +47,10 @@ main
     try:
         subprocess.run(command, check=True)
     except FileNotFoundError:
-        print("ffmpeg not found. Please install ffmpeg and ensure it is in your PATH.", file=sys.stderr)
+        print(
+            "ffmpeg not found. Please install ffmpeg and ensure it is in your PATH.",
+            file=sys.stderr,
+        )
         return 1
     except subprocess.CalledProcessError as exc:
         print(f"ffmpeg failed: {exc}", file=sys.stderr)
@@ -105,13 +75,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     try:
-        trim_video(args.input, args.start, args.end, args.output)
+        return trim_video(args.input, args.start, args.end, args.output)
     except ValueError as exc:  # pragma: no cover - user error path
         parser.error(str(exc))
-
-    return trim_video(args.input, args.start, args.end, args.output)
-    main
+        return 1
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point
     raise SystemExit(main())
+

--- a/video_trim/gui.py
+++ b/video_trim/gui.py
@@ -8,6 +8,7 @@ import sys
 import tkinter as tk
 from tkinter import filedialog, messagebox
 
+
 VIDEO_EXTENSIONS = {
     ".mp4",
     ".mov",
@@ -92,9 +93,9 @@ class VideoTrimApp(tk.Tk):
         self.end_entry = tk.Entry(end_frame)
         self.end_entry.pack()
 
-        tk.Button(self, text="Trim and Convert", command=self.trim_and_convert).pack(
-            pady=10
-        )
+        tk.Button(
+            self, text="Trim and Convert", command=self.trim_and_convert
+        ).pack(pady=10)
         tk.Button(
             self, text="Convert Directory to MKV", command=self.convert_directory
         ).pack(pady=5)
@@ -107,28 +108,6 @@ class VideoTrimApp(tk.Tk):
         tk.Button(bottom_frame, text="Exit", command=self.confirm_exit).pack(
             side="right", padx=10
         )
-
-        tk.Button(self, text="Trim and Convert", command=self.trim_and_convert).pack(pady=10)
-
-        tk.Button(
-            self, text="Convert Directory to MKV", command=self.convert_directory
-        ).pack(pady=5)
-
-        main
-        tk.Button(self, text="Convert Directory to MKV", command=self.convert_directory).pack(pady=5)
-        main
-
-        bottom_frame = tk.Frame(self)
-        bottom_frame.pack(side="bottom", fill="x", pady=10)
-        tk.Label(bottom_frame, text=f"Version {__version__}").pack(side="left", padx=10)
-
-        tk.Button(bottom_frame, text="Exit", command=self.confirm_exit).pack(
-            side="right", padx=10
-        )
-
-        tk.Button(bottom_frame, text="Exit", command=self.confirm_exit).pack(side="right", padx=10)
-
-        main
 
     def select_file(self) -> None:
         """Open a file dialog and display the selected file name."""
@@ -214,7 +193,6 @@ class VideoTrimApp(tk.Tk):
             self.quit()
 
 
-        main
 if __name__ == "__main__":  # pragma: no cover - GUI entry point
     app = VideoTrimApp()
     app.mainloop()


### PR DESCRIPTION
## Summary
- remove stray placeholders and duplicate widgets from `VideoTrimApp`
- clean up CLI by redefining `trim_video` and `main` without duplicate lines

## Testing
- `pytest -q`
- `python -m video_trim.gui` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd26e5f288320abfcf38d7ebec029