### PR TITLE
Reorder GUI buttons for directory conversion

### DIFF
--- a/video_trim/gui.py
+++ b/video_trim/gui.py
@@ -100,12 +100,12 @@ class VideoTrimApp(tk.Tk):
         self.end_entry.pack()
 
         tk.Button(
-            self, text="Trim and Convert", command=self.trim_and_convert
-        ).pack(pady=10)
-        tk.Button(
             self,
             text="Convert Directory to MKV",
             command=self.convert_directory,
+        ).pack(pady=10)
+        tk.Button(
+            self, text="Trim and Convert", command=self.trim_and_convert
         ).pack(pady=5)
 
         bottom_frame = tk.Frame(self)


### PR DESCRIPTION
## Summary
- Show the "Convert Directory to MKV" button above "Trim and Convert" in the GUI
- Adjust padding so the directory conversion button has larger spacing than the trim option

## Testing
- `pytest`
- `python -m video_trim.gui` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68befff810b08320ab179f4c181c35b9