### PR TITLE
Reorder GUI buttons for trimming workflow

### DIFF
--- a/video_trim/gui.py
+++ b/video_trim/gui.py
@@ -81,7 +81,7 @@ class VideoTrimApp(tk.Tk):
             self, text="Select Video", command=self.select_file
         ).pack(pady=5)
         tk.Button(
-            self, text="Select Folder", command=self.select_directory
+            self, text="Trim and Convert", command=self.trim_and_convert
         ).pack(pady=5)
 
         time_frame = tk.Frame(self)
@@ -105,7 +105,7 @@ class VideoTrimApp(tk.Tk):
             command=self.convert_directory,
         ).pack(pady=10)
         tk.Button(
-            self, text="Trim and Convert", command=self.trim_and_convert
+            self, text="Select Folder", command=self.select_directory
         ).pack(pady=5)
 
         bottom_frame = tk.Frame(self)


### PR DESCRIPTION
## Summary
- place Trim and Convert button next to Select Video for streamlined workflow
- move Select Folder button below Convert Directory to MKV

## Testing
- `pytest`
- `python -m video_trim.gui` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf029d202883209ae2dc4993a2166e