### PR TITLE
Increase default GUI window height

### DIFF
--- a/video_trim/gui.py
+++ b/video_trim/gui.py
@@ -63,7 +63,7 @@ class VideoTrimApp(tk.Tk):
     def __init__(self) -> None:
         super().__init__()
         self.title("Video Trim")
-        self.geometry("500x300")
+        self.geometry("500x400")
 
         self.file_path: str | None = None
         self.directory_path: str | None = None


### PR DESCRIPTION
## Summary
- Expand default VideoTrim window to 500x400 so the Exit button and version label are visible

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c18b5eaf948320ad714de1822dc7bd